### PR TITLE
Add reference picture submission

### DIFF
--- a/paint_yourself_api/services/image_styler_service.py
+++ b/paint_yourself_api/services/image_styler_service.py
@@ -7,6 +7,15 @@ from paint_yourself_api.schemas import StyledImageThemeEnum
 class ImageStylerService:
     """Service used to style user submitted images."""
 
+    def create_styled_image(
+        self, image: typing.BinaryIO, reference_image: typing.BinaryIO
+    ) -> typing.BinaryIO:
+        """Applies the reference image style to the image."""
+
+        # TODO: Apply style to the image.
+        with image as f:
+            return io.BytesIO(f.read())
+
     def create_themed_image(
         self, image: typing.BinaryIO, theme: StyledImageThemeEnum
     ) -> typing.BinaryIO:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paint-yourself-api"
-version = "1.1.0"
+version = "1.2.0"
 description = "API for the Paint Yourself mobile application"
 authors = [
 	"Claire Cassidy <clcassid@tcd.ie>",


### PR DESCRIPTION
## Purpose

Currently we can only take in the theme and use predetermined reference photos. We would like the user to uploaded their own reference photo.

## Proposed Change

Extend the `/styled-images` endpoint to take in either an input image and a theme or an input image and a reference image.

## Checklist

- [x] Add styled image function in image styler service.
- [x] Add theme or reference image route error handling.